### PR TITLE
Alter platform detection in File.nl_convert

### DIFF
--- a/lib/ptools.rb
+++ b/lib/ptools.rb
@@ -283,16 +283,7 @@ class File
       raise ArgumentError, 'Only valid for plain text files'
     end
 
-    case platform
-      when /dos|windows|win32|mswin|cygwin|mingw/i
-        format = "\cM\cJ"
-      when /unix|linux|bsd/i
-        format = "\cJ"
-      when /mac|apple|macintosh|osx/i
-        format = "\cM"
-      else
-        raise ArgumentError, "Invalid platform string"
-    end
+    format = nl_for_platform platform
 
     orig = $\ # $OUTPUT_RECORD_SEPARATOR
     $\ = format
@@ -415,6 +406,22 @@ class File
 
   private
 
+  def self.nl_for_platform( platform = 'local')
+    
+    platform = RbConfig::CONFIG["host_os"] if platform == 'local' 
+
+    case platform
+      when /dos|windows|win32|mswin|mingw/i
+        return "\cM\cJ"
+      when /unix|linux|bsd|cygwin|osx|darwin|solaris/i
+        return "\cJ"
+      when /mac|apple|macintosh/i
+        return "\cM"
+      else
+        raise ArgumentError, "Invalid platform string"
+    end
+  end
+  
   def self.bmp?(file)
     IO.read(file, 3) == "BM6"
   end

--- a/test/test_nlconvert.rb
+++ b/test/test_nlconvert.rb
@@ -25,6 +25,17 @@ class TC_Ptools_NLConvert < Test::Unit::TestCase
     @unix_file  = 'nix_test_file.txt'
   end
 
+  test "nl_for_platform basic functionality" do
+    assert_respond_to(File, :nl_for_platform)
+  end
+
+  test "nl_for_platform" do
+    assert_equal( "\cM\cJ", File.nl_for_platform('dos') )
+    assert_equal( "\cJ",    File.nl_for_platform('unix') )
+    assert_equal( "\cM",    File.nl_for_platform('mac') )
+    assert_nothing_raised{ File.nl_for_platform('local') }
+  end
+  
   test "nl_convert basic functionality" do
     assert_respond_to(File, :nl_convert)
   end


### PR DESCRIPTION
Create `nl_for_platform` for platform test
Move `osx` to `\n`
Add `darwin`, `solaris` to `\n`
Add `local` automatically pick up local platform
