### PR TITLE
Omit test resolving ~ on Windows

### DIFF
--- a/test/test_which.rb
+++ b/test/test_which.rb
@@ -97,6 +97,7 @@ class TC_FileWhich < Test::Unit::TestCase
   end
 
   test "resolves with with ~" do
+    omit_if(@@windows, "~ tests skipped on MS Windows")
     begin
       old_home = ENV['HOME']
 


### PR DESCRIPTION
~ test fails on Windows. 
