### PR TITLE
'require rubygems' not required starting with Ruby 1.9

### DIFF
--- a/ptools.gemspec
+++ b/ptools.gemspec
@@ -1,4 +1,3 @@
-require 'rubygems'
 require 'rbconfig'
 
 Gem::Specification.new do |spec|


### PR DESCRIPTION
Removed the **require 'rubygems'** line from ptools.gemspec since
the **require** statement is not required starting with Ruby 1.9.

Reference: http://guides.rubygems.org/patterns/#requiring-rubygems