### PR TITLE
Optional binary percentage

### DIFF
--- a/lib/ptools.rb
+++ b/lib/ptools.rb
@@ -79,6 +79,10 @@ class File
   # It performs a "best guess" based on a simple test of the first
   # +File.blksize+ characters, or 4096, whichever is smaller.
   #
+  # By default it will check to see if more than 30 percent of the characters
+  # are non-text characters. If so, the method returns true. You can configure
+  # this percentage by passing your own as a second argument.
+  #
   # Example:
   #
   #   File.binary?('somefile.exe') # => true
@@ -87,13 +91,13 @@ class File
   # Based on code originally provided by Ryan Davis (which, in turn, is
   # based on Perl's -B switch).
   #
-  def self.binary?(file)
+  def self.binary?(file, percentage = 0.30)
     return false if image?(file)
     bytes = File.stat(file).blksize
     bytes = 4096 if bytes > 4096
     s = (File.read(file, bytes) || "")
     s = s.encode('US-ASCII', :undef => :replace).split(//)
-    ((s.size - s.grep(" ".."~").size) / s.size.to_f) > 0.30
+    ((s.size - s.grep(" ".."~").size) / s.size.to_f) > percentage
   end
 
   # Looks for the first occurrence of +program+ within +path+.

--- a/lib/ptools.rb
+++ b/lib/ptools.rb
@@ -3,7 +3,7 @@ require 'win32/file' if File::ALT_SEPARATOR
 
 class File
   # The version of the ptools library.
-  PTOOLS_VERSION = '1.3.3'
+  PTOOLS_VERSION = '1.3.4'.freeze
 
   # :stopdoc:
 

--- a/test/test_binary.rb
+++ b/test/test_binary.rb
@@ -47,6 +47,11 @@ class TC_Ptools_Binary < Test::Unit::TestCase
     assert_false(File.binary?(@gif_file))
   end
 
+  test "File.binary? accepts an optional percentage argument" do
+    assert_false(File.binary?(@txt_file, 0.50))
+    assert_true(File.binary?(@txt_file, 0.05))
+  end
+
   test "File.binary? raises an error if the file cannot be found" do
     assert_raise_kind_of(SystemCallError){ File.binary?('bogus') }
   end

--- a/test/test_constants.rb
+++ b/test/test_constants.rb
@@ -15,7 +15,7 @@ class TC_Ptools_Constants < Test::Unit::TestCase
   end
 
   test "PTOOLS_VERSION constant is set to expected value" do
-    assert_equal('1.3.3', File::PTOOLS_VERSION)
+    assert_equal('1.3.4', File::PTOOLS_VERSION)
   end
 
   test "IMAGE_EXT constant is set to array of values" do


### PR DESCRIPTION
Make the exact percentage for the binary detection heuristic optional as per the suggestion brought up in https://github.com/djberg96/ptools/issues/28