### PR TITLE
When calling File.binary on a 0 bytes file will throw an error

### DIFF
--- a/lib/ptools.rb
+++ b/lib/ptools.rb
@@ -92,6 +92,7 @@ class File
   # based on Perl's -B switch).
   #
   def self.binary?(file, percentage = 0.30)
+    return false if File.stat(file).zero? 
     return false if image?(file)
     return false if check_bom?(file)
     bytes = File.stat(file).blksize

--- a/test/test_binary.rb
+++ b/test/test_binary.rb
@@ -21,6 +21,7 @@ class TC_Ptools_Binary < Test::Unit::TestCase
 
   def setup
     @txt_file = File.join(@@dirname, 'txt', 'english.txt')
+    @emp_file = File.join(@@dirname, 'txt', 'empty.txt')
     @uni_file = File.join(@@dirname, 'txt', 'korean.txt')
     @utf_file = File.join(@@dirname, 'txt', 'english.utf16')
     @png_file = File.join(@@dirname, 'img', 'test.png')
@@ -38,6 +39,7 @@ class TC_Ptools_Binary < Test::Unit::TestCase
   end
 
   test "File.binary? returns false for text files" do
+    assert_false(File.binary?(@emp_file))
     assert_false(File.binary?(@txt_file))
     assert_false(File.binary?(@uni_file))
     assert_false(File.binary?(@utf_file))


### PR DESCRIPTION
Investigating a fix for https://github.com/thesp0nge/dawnscanner/issues/245, i have identified the error comes from an empty file. 

```
Traceback (most recent call last):
	11: from $rbenv_dir/bin/dawn:23:in `<main>'
	10: from $rbenv_dir/bin/dawn:23:in `load'
	 9: from $rbenv_dir/lib/ruby/gems/2.5.0/gems/dawnscanner-1.6.9/bin/dawn:249:in `<top (required)>'
	 8: from $rbenv_dir/lib/ruby/gems/2.5.0/gems/dawnscanner-1.6.9/lib/dawn/engine.rb:314:in `apply_all'
	 7: from $rbenv_dir/lib/ruby/gems/2.5.0/gems/dawnscanner-1.6.9/lib/dawn/engine.rb:314:in `each'
	 6: from $rbenv_dir/lib/ruby/gems/2.5.0/gems/dawnscanner-1.6.9/lib/dawn/engine.rb:315:in `block in apply_all'
	 5: from $rbenv_dir/lib/ruby/gems/2.5.0/gems/dawnscanner-1.6.9/lib/dawn/engine.rb:392:in `_do_apply'
	 4: from $rbenv_dir/lib/ruby/gems/2.5.0/gems/dawnscanner-1.6.9/lib/dawn/kb/pattern_match_check.rb:60:in `vuln?'
	 3: from $rbenv_dir/lib/ruby/gems/2.5.0/gems/dawnscanner-1.6.9/lib/dawn/kb/pattern_match_check.rb:60:in `each'
	 2: from $rbenv_dir/lib/ruby/gems/2.5.0/gems/dawnscanner-1.6.9/lib/dawn/kb/pattern_match_check.rb:64:in `block in vuln?'
	 1: from $rbenv_dir/lib/ruby/gems/2.5.0/gems/ptools-1.3.6/lib/ptools.rb:96:in `binary?'
$rbenv_dir/lib/ruby/gems/2.5.0/gems/ptools-1.3.6/lib/ptools.rb:440:in `check_bom?': undefined method `force_encoding' for nil:NilClass (NoMethodError)
```