### PR TITLE
Fix access modifiers, update image? method

### DIFF
--- a/lib/ptools.rb
+++ b/lib/ptools.rb
@@ -19,14 +19,19 @@ class File
     MSWINDOWS = false
   end
 
-  IMAGE_EXT = %w[.bmp .gif .jpg .jpeg .png]
+  if File::ALT_SEPARATOR
+    private_constant :WIN32EXTS
+    private_constant :MSWINDOWS
+  end
+
+  IMAGE_EXT = %w[.bmp .gif .jpg .jpeg .png .ico]
 
   # :startdoc:
 
   # Returns whether or not the file is an image. Only JPEG, PNG, BMP,
   # GIF, and ICO are checked against.
   #
-  # This method does some simple read and extension checks. For a version
+  # This reads and checks the first few bytes of the file. For a version
   # that is more robust, but which depends on a 3rd party C library (and is
   # difficult to build on MS Windows), see the 'filemagic' library.
   #
@@ -39,9 +44,8 @@ class File
   # http://en.wikipedia.org/wiki/Magic_number_(programming)
   #
   def self.image?(file)
-    bool = IMAGE_EXT.include?(File.extname(file).downcase)
-    bool = bmp?(file) || jpg?(file) || png?(file) || gif?(file) || tiff?(file) || ico?(file)
-    bool
+    IMAGE_EXT.include?(File.extname(file).downcase) &&
+    (bmp?(file) || jpg?(file) || png?(file) || gif?(file) || tiff?(file) || ico?(file))
   end
 
   # Returns whether or not +file+ is a binary non-image file, i.e. executable,
@@ -402,8 +406,6 @@ class File
     end
   end
 
-  private
-
   # Returns whether or not the given +text+ contains a BOM marker.
   # If present, we can generally assume it's a text file.
   #
@@ -417,6 +419,8 @@ class File
 
     bool
   end
+
+  private_class_method :check_bom?
 
   def self.nl_for_platform(platform)
     platform = RbConfig::CONFIG["host_os"] if platform == 'local'

--- a/lib/ptools.rb
+++ b/lib/ptools.rb
@@ -431,6 +431,8 @@ class File
 
   private_class_method :check_bom?
 
+  # Returns the newline characters for the given platform.
+  #
   def self.nl_for_platform(platform)
     platform = RbConfig::CONFIG["host_os"] if platform == 'local'
 
@@ -446,22 +448,32 @@ class File
     end
   end
 
+  # Is the file a bitmap file?
+  #
   def self.bmp?(file)
     IO.read(file, 3) == "BM6"
   end
 
+  # Is the file a jpeg file?
+  #
   def self.jpg?(file)
     IO.read(file, 10, nil, :encoding => 'binary') == "\377\330\377\340\000\020JFIF".force_encoding(Encoding::BINARY)
   end
 
+  # Is the file a png file?
+  #
   def self.png?(file)
     IO.read(file, 4, nil, :encoding => 'binary') == "\211PNG".force_encoding(Encoding::BINARY)
   end
 
+  # Is the file a gif?
+  #
   def self.gif?(file)
     ['GIF89a', 'GIF97a'].include?(IO.read(file, 6))
   end
 
+  # Is the file a tiff?
+  #
   def self.tiff?(file)
     return false if File.size(file) < 12
 
@@ -483,6 +495,8 @@ class File
     true
   end
 
+  # Is the file an ico file?
+  #
   def self.ico?(file)
     ["\000\000\001\000", "\000\000\002\000"].include?(IO.read(file, 4, nil, :encoding => 'binary'))
   end

--- a/lib/ptools.rb
+++ b/lib/ptools.rb
@@ -35,6 +35,10 @@ class File
   # that is more robust, but which depends on a 3rd party C library (and is
   # difficult to build on MS Windows), see the 'filemagic' library.
   #
+  # By default the filename extension is also checked. You can disable this
+  # by passing false as the second argument, in which case only the contents
+  # are checked.
+  #
   # Examples:
   #
   #    File.image?('somefile.jpg') # => true
@@ -43,9 +47,14 @@ class File
   # The approach I used here is based on information found at
   # http://en.wikipedia.org/wiki/Magic_number_(programming)
   #
-  def self.image?(file)
-    IMAGE_EXT.include?(File.extname(file).downcase) &&
-    (bmp?(file) || jpg?(file) || png?(file) || gif?(file) || tiff?(file) || ico?(file))
+  def self.image?(file, check_file_extension = true)
+    bool = bmp?(file) || jpg?(file) || png?(file) || gif?(file) || tiff?(file) || ico?(file)
+
+    if check_file_extension
+      bool = bool && IMAGE_EXT.include?(File.extname(file).downcase)
+    end
+
+    bool
   end
 
   # Returns whether or not +file+ is a binary non-image file, i.e. executable,

--- a/spec/constants_spec.rb
+++ b/spec/constants_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe File, :constants do
   end
 
   example "IMAGE_EXT constant is set to array of values" do
-    expect(File::IMAGE_EXT.sort).to eq(%w[.bmp .gif .jpeg .jpg .png])
+    expect(File::IMAGE_EXT).to match_array(%w[.bmp .gif .ico .jpeg .jpg .png])
   end
 
   example "WINDOWS constant is defined on MS Windows" do

--- a/spec/constants_spec.rb
+++ b/spec/constants_spec.rb
@@ -20,14 +20,4 @@ RSpec.describe File, :constants do
   example "IMAGE_EXT constant is set to array of values" do
     expect(File::IMAGE_EXT).to match_array(%w[.bmp .gif .ico .jpeg .jpg .png])
   end
-
-  example "WINDOWS constant is defined on MS Windows" do
-    skip "skipped unless MS Windows" unless windows
-    expect(File::MSWINDOWS).not_to be_nil
-  end
-
-  example "WIN32EXTS constant is defined on MS Windows" do
-    skip "skipped unless MS Windows" unless windows
-    expect(File::WIN32EXTS).not_to be_nil
-  end
 end


### PR DESCRIPTION
At the moment the `private` access modifier isn't actually doing anything, so I've removed it and only applied it to `check_bom` method. The other methods weren't really meant to be public, but since I can see some value in leaving them public, not to mention the value in not breaking people's existing code, I've left them as public.

In addition, the rubocop linter exposed a bug in the `image?` method where the filename extension check was essentially ignored. Consequently the method has been updated to reincorporate that logic, though with the option to disable it if desired.

However, there were 2 constants only defined on Windows that were never meant to be public, so consequently they have been made private.