### PR TITLE
Refactor nlconvert method

### DIFF
--- a/lib/ptools.rb
+++ b/lib/ptools.rb
@@ -293,33 +293,25 @@ class File
     format = nl_for_platform(platform)
 
     if old_file == new_file
-      require 'fileutils'
       require 'tempfile'
-
-      begin
-        temp_name = Time.new.strftime('%Y%m%d%H%M%S')
-        tf = Tempfile.new('ruby_temp_' + temp_name)
-        tf.open
-
-        IO.foreach(old_file) do |line|
-          line.chomp!
-          tf.print("#{line}#{format}")
-        end
-      ensure
-        tf.close if tf && !tf.closed?
-      end
-
-      File.delete(old_file)
-      FileUtils.mv(tf.path, old_file)
+      temp_name = Time.new.strftime('%Y%m%d%H%M%S')
+      nf = Tempfile.new('ruby_temp_' + temp_name)
     else
-      begin
-        nf = File.new(new_file, 'w')
-        IO.foreach(old_file) do |line|
-          line.chomp!
-          nf.print("#{line}#{format}")
-        end
-      ensure
-        nf.close if nf && !nf.closed?
+      nf = File.new(new_file, 'w')
+    end
+
+    begin
+      nf.open if old_file == new_file
+      IO.foreach(old_file) do |line|
+        line.chomp!
+        nf.print("#{line}#{format}")
+      end
+    ensure
+      nf.close if nf && !nf.closed?
+      if old_file == new_file
+        require 'fileutils'
+        File.delete(old_file)
+        FileUtils.mv(nf.path, old_file)
       end
     end
 

--- a/lib/ptools.rb
+++ b/lib/ptools.rb
@@ -292,9 +292,6 @@ class File
 
     format = nl_for_platform(platform)
 
-    orig = $\ # $OUTPUT_RECORD_SEPARATOR
-    $\ = format
-
     if old_file == new_file
       require 'fileutils'
       require 'tempfile'
@@ -306,7 +303,7 @@ class File
 
         IO.foreach(old_file) do |line|
           line.chomp!
-          tf.print line
+          tf.print("#{line}#{format}")
         end
       ensure
         tf.close if tf && !tf.closed?
@@ -319,14 +316,13 @@ class File
         nf = File.new(new_file, 'w')
         IO.foreach(old_file) do |line|
           line.chomp!
-          nf.print line
+          nf.print("#{line}#{format}")
         end
       ensure
         nf.close if nf && !nf.closed?
       end
     end
 
-    $\ = orig
     self
   end
 


### PR DESCRIPTION
Since `$/` is going away (along with other special globals), let's remove that since it isn't strictly necessary.

I also removed some code duplication within the method.