### PR TITLE
Add 3.0, JRuby, Truffleruby to workflow matrix

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -18,8 +18,13 @@ jobs:
   test:
     strategy:
       matrix:
-        ruby-version: ['2.6', '2.7']
+        ruby-version: ['2.6', '2.7', '3.0', 'jruby', 'truffleruby']
         platform: [ubuntu-latest, macos-latest, windows-latest]
+        exclude:
+          - ruby-version: truffleruby
+            platform: windows-latest
+          - ruby-version: jruby
+            platform: windows-latest
     runs-on: ${{ matrix.platform }}
 
     steps:


### PR DESCRIPTION
But skip Java and Truffleruby on Windows for now.