### PR TITLE
Update binary? method, change license

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## 1.5.0 - 5-Dec-2022
+* Change license to Apache-2.0.
+* Altered the File.binary? method. It no longer accepts a second argument,
+  having changed the way it checks for binary files internally, which is
+  now much simpler.
+
 ## 1.4.3 - 26-Nov-2022
 * Added more image specs.
 * Updated the File.bmp? method. It now looks at the first six bytes, and

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,177 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/MANIFEST.md
+++ b/MANIFEST.md
@@ -1,4 +1,5 @@
 * CHANGES.md
+* LICENSE
 * README.md
 * MANIFEST.md
 * Gemfile

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ And thanks to any and all contributors!
 Add whatever other tools people think might be useful.
    
 ## License
-Artistic-2.0
+Apache-2.0
     
 ## Copyright
 (C) 2003-2022 Daniel J. Berger

--- a/lib/ptools.rb
+++ b/lib/ptools.rb
@@ -56,32 +56,25 @@ class File
   end
 
   # Returns whether or not +file+ is a binary non-image file, i.e. executable,
-  # shared object, ect. Note that this is NOT guaranteed to be 100% accurate.
-  # It performs a "best guess" based on a simple test of the first
-  # +File.blksize+ characters, or 4096, whichever is smaller.
+  # shared object, etc.
   #
-  # By default it will check to see if more than 30 percent of the characters
-  # are non-text characters. If so, the method returns true. You can configure
-  # this percentage by passing your own as a second argument.
+  # Internally this method simply looks for a double null sequence. This will
+  # work for the vast majority of cases, but it is not guaranteed to be
+  # absolutely accurate.
   #
   # Example:
   #
   #   File.binary?('somefile.exe') # => true
   #   File.binary?('somefile.txt') # => false
-  #--
-  # Based on code originally provided by Ryan Davis (which, in turn, is
-  # based on Perl's -B switch).
   #
-  def self.binary?(file, percentage = 0.30)
+  def self.binary?(file)
     return false if File.stat(file).zero?
     return false if image?(file)
     return false if check_bom?(file)
 
     bytes = File.stat(file).blksize
     bytes = 4096 if bytes > 4096
-    s = (File.read(file, bytes) || '')
-    s = s.encode('US-ASCII', :undef => :replace).chars
-    ((s.size - s.grep(' '..'~').size) / s.size.to_f) > percentage
+    (File.read(file, bytes) || '').include?("\u0000\u0000")
   end
 
   # Looks for the first occurrence of +program+ within +path+.

--- a/lib/ptools.rb
+++ b/lib/ptools.rb
@@ -3,7 +3,7 @@ require 'win32/file' if File::ALT_SEPARATOR
 
 class File
   # The version of the ptools library.
-  PTOOLS_VERSION = '1.4.3'.freeze
+  PTOOLS_VERSION = '1.5.0'.freeze
 
   # :stopdoc:
 

--- a/ptools.gemspec
+++ b/ptools.gemspec
@@ -2,8 +2,8 @@ require 'rbconfig'
 
 Gem::Specification.new do |spec|
   spec.name       = 'ptools'
-  spec.version    = '1.4.3'
-  spec.license    = 'Artistic-2.0'
+  spec.version    = '1.5.0'
+  spec.license    = 'Apache-2.0'
   spec.author     = 'Daniel J. Berger'
   spec.email      = 'djberg96@gmail.com'
   spec.homepage   = 'https://github.com/djberg96/ptools'

--- a/spec/binary_spec.rb
+++ b/spec/binary_spec.rb
@@ -31,6 +31,12 @@ RSpec.describe File, :binary do
     expect(described_class.binary?(bin_file)).to be true
   end
 
+  example 'File.binary? returns true for unix binary files', :unix_only => true do
+    expect(described_class.binary?('/bin/df')).to be true
+    expect(described_class.binary?('/bin/chmod')).to be true
+    expect(described_class.binary?('/bin/cat')).to be true
+  end
+
   example 'File.binary? returns false for text files' do
     expect(described_class.binary?(@emp_file)).to be false
     expect(described_class.binary?(@txt_file)).to be false
@@ -42,11 +48,6 @@ RSpec.describe File, :binary do
     expect(described_class.binary?(@png_file)).to be false
     expect(described_class.binary?(@jpg_file)).to be false
     expect(described_class.binary?(@gif_file)).to be false
-  end
-
-  example 'File.binary? accepts an optional percentage argument' do
-    expect(described_class.binary?(@txt_file, 0.50)).to be false
-    expect(described_class.binary?(@txt_file, 0.05)).to be true
   end
 
   example 'File.binary? raises an error if the file cannot be found' do

--- a/spec/constants_spec.rb
+++ b/spec/constants_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe File, :constants do
   let(:windows) { File::ALT_SEPARATOR }
 
   example 'PTOOLS_VERSION constant is set to expected value' do
-    expect(File::PTOOLS_VERSION).to eq('1.4.3')
+    expect(File::PTOOLS_VERSION).to eq('1.5.0')
     expect(File::PTOOLS_VERSION.frozen?).to be true
   end
 


### PR DESCRIPTION
This PR simplifies the `File.binary?` check by looking for a double null sequence instead of the heuristic we had there before. In testing, this seems to work just as well, and is much easier. It removes the optional second argument.

I also changed the license to Apache-2.0. This puts it in line with the vast majority of my other libraries.

Both of these changes warranted a version bump.