### PR TITLE
Binary encoding revert

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -82,7 +82,7 @@ namespace 'spec' do
 
   RSpec::Core::RakeTask.new(:all) do |t|
     t.pattern = 'spec/*_spec.rb'
-    t.rspec_opts = '-f documentation'
+    t.rspec_opts = '-f documentation -w'
   end
 end
 

--- a/lib/ptools.rb
+++ b/lib/ptools.rb
@@ -332,7 +332,7 @@ class File
   # 'lines'.
   #
   def self.wc(filename, option = 'all')
-    option.downcase!
+    option = option.downcase
     valid = %w[all bytes characters chars lines words]
 
     raise ArgumentError, "Invalid option: '#{option}'" unless valid.include?(option)

--- a/lib/ptools.rb
+++ b/lib/ptools.rb
@@ -430,19 +430,19 @@ class File
   # Is the file a jpeg file?
   #
   def self.jpg?(file)
-    File.read(file, 10, nil, :encoding => 'binary') == "\xFF\xD8\xFF\xE0\x00\x10JFIF".force_encoding(Encoding::BINARY)
+    File.read(file, 10, nil, :encoding => 'binary') == String.new("\377\330\377\340\000\020JFIF").force_encoding(Encoding::BINARY)
   end
 
   # Is the file a png file?
   #
   def self.png?(file)
-    File.read(file, 4, nil, :encoding => 'binary') == "\x89PNG".force_encoding(Encoding::BINARY)
+    File.read(file, 4, nil, :encoding => 'binary') == String.new("\211PNG").force_encoding(Encoding::BINARY)
   end
 
   # Is the file a gif?
   #
   def self.gif?(file)
-    %w[GIF89a GIF97a].include?(File.read(file, 6, nil, :encoding => 'binary'))
+    %w[GIF89a GIF97a].include?(File.read(file, 6))
   end
 
   # Is the file a tiff?
@@ -450,7 +450,7 @@ class File
   def self.tiff?(file)
     return false if File.size(file) < 12
 
-    bytes = File.read(file, 4, nil, :encoding => 'binary')
+    bytes = File.read(file, 4)
 
     # II is Intel, MM is Motorola
     return false if bytes[0..1] != 'II' && bytes[0..1] != 'MM'
@@ -465,6 +465,6 @@ class File
   # Is the file an ico file?
   #
   def self.ico?(file)
-    ["\x00\x00\x01\x00".force_encoding(Encoding::BINARY), "\x00\x00\x02\x00".force_encoding(Encoding::BINARY)].include?(File.read(file, 4, nil, :encoding => 'binary'))
+    ["\000\000\001\000", "\000\000\002\000"].include?(File.read(file, 4, nil, :encoding => 'binary'))
   end
 end


### PR DESCRIPTION
Reverts https://github.com/djberg96/ptools/commit/574ebb35b1bb3111b1f76eae3ea9f0af71e17332

I found another one in the `wc` method, so that's been updated as well.

While I was here I added the `-w` option to the Rake test task so I should spot these more easily going forward.